### PR TITLE
Changing parameters to avoid  challenge workarounds

### DIFF
--- a/challenges/challenge05.md
+++ b/challenges/challenge05.md
@@ -49,16 +49,16 @@ Optional output: `a: string, b: string, c: string`
 Input:
 
 ```
-public int Sum(int y, int x) {
-    return y + x;
+public int Sum(int a, int b) {
+    return a + b;
 }
 ```
 
 Desired output:
 
 ```
-public string Append(string a, string b) {
-    return a + b;
+public string Append(string x, string y) {
+    return x + y;
 }
 ```
 

--- a/challenges/challenge05.md
+++ b/challenges/challenge05.md
@@ -49,7 +49,7 @@ Optional output: `a: string, b: string, c: string`
 Input:
 
 ```
-public int Sum(int a, int b) {
+public int Aggregate(int a, int b) {
     return a + b;
 }
 ```
@@ -57,7 +57,7 @@ public int Sum(int a, int b) {
 Desired output:
 
 ```
-public string Append(string x, string y) {
+public string Sum(string x, string y) {
     return x + y;
 }
 ```


### PR DESCRIPTION
The original challenge could be accomplished without using selection within brackets.

1. Select all function
2. `:%s/y/a/g`
3. `:%s/x/b/g`
4. `:%s/Sum/Append/g`

It actually does not matter the order of the last 3 steps.

This change will enforce using selection within brackets because there is a `b` in the `public` word, and an `a` on Aggregate